### PR TITLE
Added the official Link List as a topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ As we all are waiting at home for the rc3 to start, there is no wiki yet and I t
 [Pull request](https://github.com/askeron/awesome-rc3/edit/master/README.md) are welcome.
 For the old linklist of 2020 take a look in the [archive](https://github.com/askeron/awesome-rc3/blob/master/archive-2020.md).
 
-### official Link List: [https://links.rc3.world/](https://links.rc3.world/)
-While this is a community project. There is an official link list here: [https://links.rc3.world/](https://links.rc3.world/)
+### official URL for this list: [https://links.rc3.world/](https://links.rc3.world/)
 
 ## rc3 itself
 - [rc3.world](https://rc3.world/)
-- [rc3.world links](https://links.rc3.world/)
+- [rc3.world official link list](https://links.rc3.world/)
 - [howto.rc3.world](https://howto.rc3.world/)
 - [first workadventure design update](https://twitter.com/Mu11ana/status/1466749205213556740)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ As we all are waiting at home for the rc3 to start, there is no wiki yet and I t
 [Pull request](https://github.com/askeron/awesome-rc3/edit/master/README.md) are welcome.
 For the old linklist of 2020 take a look in the [archive](https://github.com/askeron/awesome-rc3/blob/master/archive-2020.md).
 
-### official URL: [https://links.rc3.io/](https://links.rc3.io/)
+### official Link List: [https://links.rc3.world/](https://links.rc3.world/)
+While this is a community project. There is an official link list here: [https://links.rc3.world/](https://links.rc3.world/)
 
 ## rc3 itself
 - [rc3.world](https://rc3.world/)


### PR DESCRIPTION
While we always endorse community projects, I think it's a bit difficult to differ between links.rc3.world & links.rc3.io.
To catch anyone, who wanted to browse to the official page (links.rc3.world) (i.e. persons in need of abuse contacts, press, etc.) This PR changes the section of "official URL" with the link to the community driven link list, to "official Link List" with the curated link list from the rc3.world team.